### PR TITLE
google-cloud-sdk package was deleted from Ubuntu canonical partner repository

### DIFF
--- a/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
+++ b/modules/client/templates/scripts/forseti-client/forseti_client_startup_script.sh.tpl
@@ -8,6 +8,9 @@ USER_HOME=/home/ubuntu
 # Ubuntu update.
 sudo apt-get update -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+sudo apt-get --assume-yes install apt-transport-https ca-certificates gnupg
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 sudo apt-get update -y
 sudo apt-get --assume-yes install google-cloud-sdk git unzip
 

--- a/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
+++ b/modules/server/templates/scripts/forseti-server/forseti_server_startup_script.sh.tpl
@@ -19,6 +19,9 @@ fi
 echo "Forseti Startup - Updating Ubuntu."
 sudo apt-get update -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+sudo apt-get --assume-yes install apt-transport-https ca-certificates gnupg
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 sudo apt-get update -y
 sudo apt-get --assume-yes install google-cloud-sdk git unzip
 


### PR DESCRIPTION
## Issue
Since 2021/01/15, Ubuntu canonical partner repository is no longer support google-cloud-sdk.
current GCE google-cloud-sdk install way fails.
https://www.ubuntuupdates.org/package/canonical_partner/bionic/partner/base/google-cloud-sdk


I fixed startup-script.

## Error
```
Jan 19 06:11:55 forseti-server-vm-dev startup-script: INFO startup-script: No apt package "google-cloud-sdk", but there is a snap with that name.
Jan 19 06:11:55 forseti-server-vm-dev startup-script: INFO startup-script: Try "snap install google-cloud-sdk"
Jan 19 06:11:55 forseti-server-vm-dev startup-script: INFO startup-script: E: Unable to locate package google-cloud-sdk
Jan 19 06:11:55 forseti-server-vm-dev startup-script: INFO startup-script: Return code 100.
Jan 19 06:11:55 forseti-server-vm-dev startup-script: INFO Finished running startup scripts.
```

## After Fixed it
It works properly.

```
startup-script: INFO startup-script: Forseti Startup - Execution of startup script finished.
startup-script: INFO startup-script: Return code 0.
startup-script: INFO Finished running startup scripts.

```



