### PR TITLE
add cloudsql_suffix parameter 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -175,6 +175,7 @@ module "server" {
 
 module "cloudsql" {
   source                       = "./modules/cloudsql"
+  cloudsql_suffix              = var.cloudsql_suffix
   cloudsql_db_name             = var.cloudsql_db_name
   cloudsql_disk_size           = var.cloudsql_disk_size
   cloudsql_net_write_timeout   = var.cloudsql_net_write_timeout

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -22,7 +22,7 @@ locals {
   cloudsql_zone     = "${var.cloudsql_region}-c"
   network_project   = var.network_project != "" ? var.network_project : var.project_id
   cloudsql_password = var.cloudsql_password == "" ? random_password.password.result : var.cloudsql_password
-  random_hash       = var.suffix
+  random_hash       = var.cloudsql_suffix == "" ? var.suffix : var.cloudsql_suffix
 }
 
 #------------------------------------#

--- a/modules/cloudsql/variables.tf
+++ b/modules/cloudsql/variables.tf
@@ -50,6 +50,11 @@ variable "enable_service_networking" {
 #------------#
 # Forseti db #
 #------------#
+variable "cloudsql_suffix" {
+  description = "Cloud SQL suffix because Cloud SQL can't reuse the name of the deleted instance until one week"
+  default     = ""
+}
+
 variable "cloudsql_region" {
   description = "CloudSQL region"
   default     = "us-central1"

--- a/modules/on_gke/main.tf
+++ b/modules/on_gke/main.tf
@@ -477,6 +477,7 @@ module "client" {
 #------------------#
 module "cloudsql" {
   source                       = "../cloudsql"
+  cloudsql_suffix              = var.cloudsql_suffix
   cloudsql_disk_size           = var.cloudsql_disk_size
   cloudsql_private             = var.cloudsql_private
   cloudsql_region              = var.cloudsql_region

--- a/modules/on_gke/variables.tf
+++ b/modules/on_gke/variables.tf
@@ -842,6 +842,11 @@ variable "client_private" {
 #------------#
 # Forseti db #
 #------------#
+variable "cloudsql_suffix" {
+  description = "Cloud SQL suffix because Cloud SQL can't reuse the name of the deleted instance until one week"
+  default     = ""
+}
+
 variable "cloudsql_region" {
   description = "CloudSQL region"
   default     = "us-central1"

--- a/variables.tf
+++ b/variables.tf
@@ -866,6 +866,11 @@ variable "client_service_account" {
 #------------#
 # Forseti db #
 #------------#
+variable "cloudsql_suffix" {
+  description = "Cloud SQL suffix because Cloud SQL can't reuse the name of the deleted instance until one week"
+  default     = ""
+}
+
 variable "cloudsql_region" {
   description = "CloudSQL region"
   default     = "us-central1"


### PR DESCRIPTION
Cloud SQL can't reuse the name of the deleted instance until one week.

so, add cloudsql_suffix parameter.