### PR TITLE
resource "google_storage_bucket_object" "main" の content_language パラメータを指定

### DIFF
--- a/modules/rules/main.tf
+++ b/modules/rules/main.tf
@@ -62,6 +62,7 @@ resource "google_storage_bucket_object" "main" {
   name    = element(local.files, count.index)
   content = element(data.template_file.main.*.rendered, count.index)
   bucket  = var.server_gcs_module.forseti-server-storage-bucket
+  content_language = "en"
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
`gsutil cp`を使った場合にオブジェクトのContent-Languageがデフォルトで"en"になってしまうので、
`resource "google_storage_bucket_object" "main"`の差分が検出されてしまう。
```
- content_language = "en" -> null # forces replacement
```
それを避けるため、content_language パラメータを指定する。