### PR TITLE
各種Terraform providerをM1 Macに対応したバージョンに上げる

### DIFF
--- a/modules/client/versions.tf
+++ b/modules/client/versions.tf
@@ -18,6 +18,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = "~> 3.7"
+    google = "~> 3.63"
   }
 }

--- a/modules/server/versions.tf
+++ b/modules/server/versions.tf
@@ -18,6 +18,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = "~> 3.7"
+    google = "~> 3.63"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -17,15 +17,15 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google      = "~> 3.7"
-    google-beta = "~> 3.7"
-    helm        = "~> 0.10"
-    http        = "~> 1.1"
+    google      = "~> 3.63"
+    google-beta = "~> 3.63"
+    helm        = "~> 2.6"
+    http        = "~> 2.2"
     kubernetes  = "~> 1.10"
-    local       = "~> 1.4"
-    null        = "~> 2.0"
-    random      = "~> 2.0"
-    template    = "~> 2.0"
-    tls         = "~> 2.1"
+    local       = "~> 2.2"
+    null        = "~> 3.1"
+    random      = "~> 3.1"
+    template    = "~> 2.2"
+    tls         = "~> 3.4"
   }
 }


### PR DESCRIPTION
各種Terraform providerをM1 Macに対応したバージョンに上げる。

hashicorp/templateのみプロバイダ自体がdeprecatedになっていて対応するバージョンが存在しないので、
最新のバージョンにしてローカルでビルドしたパッケージを利用する。